### PR TITLE
Fix to previously stated issues

### DIFF
--- a/Player.js
+++ b/Player.js
@@ -3,44 +3,17 @@ class Player extends Phaser.GameObjects.Sprite {
 		super(scene, x, y, 'player');
 
 		this.scene = scene;
+		this.icon = icon;
+		this.x = x;
+		this.y = y;
+		console.log(this.x);
+		console.log(this.y);
 
-		//create the animations
-		const anims = scene.anims;
-		anims.create({
-			key: 'left',
-			frames: anims.generateFrameNumbers('characters5', {start: icon+11, end: icon+13}),
-			frameRate: 3,
-			repeat: -1,
-			yoyo: true
-		});
+		//create the an
+		this.animate(scene);
 
-
-		anims.create({
-			key: 'down',
-			frames: anims.generateFrameNumbers('characters5', {start: icon-1, end: icon+1}),
-			frameRate: 3,
-			repeat: -1,
-			yoyo: true
-		});
-
-		anims.create({
-			key: 'up',
-			frames: anims.generateFrameNumbers('characters5', {start: icon+35, end: icon+37}),
-			frameRate: 3,
-			repeat: -1,
-			yoyo: true
-		});
-
-		anims.create({
-			key: 'right',
-			frames: anims.generateFrameNumbers('characters5', {start: icon+23, end: icon+25}),
-			frameRate: 3,
-			repeat: -1,
-			yoyo: true
-		});
-
-		//Create physics-based sprite to move
-		this.sprite = scene.physics.add.sprite(x, y, 'characters5', icon);
+		//Create physics-basedimations sprite to move
+		this.sprite = scene.physics.add.sprite(this.x, this.y, 'characters5', this.icon);
 		this.sprite.body.collideWorldBounds=true;
 		this.sprite.body.setGravityY(0);
 
@@ -81,29 +54,76 @@ class Player extends Phaser.GameObjects.Sprite {
 
 
 		if(this.key_A.isDown) {
-			this.sprite.anims.play('left', true);
+			this.sprite.anims.play('left'+this.icon, true);
 		}
 		else if(this.key_D.isDown) {
-			this.sprite.anims.play('right', true);
+			this.sprite.anims.play('right'+this.icon, true);
 		}
 		else if(this.key_W.isDown) {
-			this.sprite.anims.play('up', true);
+			this.sprite.anims.play('up'+this.icon, true);
 		}
 		else if(this.key_S.isDown) {
-			this.sprite.anims.play('down', true);
+			this.sprite.anims.play('down'+this.icon, true);
 		}
 		else {
 			this.sprite.anims.stop();
-			console.log('hi');
-/*			if (prevVelocity.x < 0) this.sprite.setTexture('characters5', icon+12);
-			else if (prevVelocity.x > 0) this.sprite.setTexture('characters5', icon+24);
-			else if (prevVelocity.y < 0) this.sprite.setTexture('characters5', icon+36);
-			else if (prevVelocity.y > 0) this.sprite.setTexture('characters5', icon);
-*/		}		
+
+			if (prevVelocity.x < 0) this.sprite.setTexture('characters5', this.icon+12);
+			else if (prevVelocity.x > 0) this.sprite.setTexture('characters5', this.icon+24);
+			else if (prevVelocity.y < 0) this.sprite.setTexture('characters5', this.icon+36);
+			else if (prevVelocity.y > 0) this.sprite.setTexture('characters5', this.icon);
+		}		
 	}
 
 	destroy() {
 		this.sprite.destroy();
 	}
 
+	animate(scene) {
+		this.scene = scene;
+		var pc = 1;
+		var anims = scene.anims;
+		do {
+			anims.create({
+				key: 'left' + pc,
+				frames: anims.generateFrameNumbers('characters5', {start: pc+11, end: pc+13}),
+				frameRate: 3,
+				repeat: -1,
+				yoyo: true
+			});
+
+
+			anims.create({
+				key: 'down' + pc,
+				frames: anims.generateFrameNumbers('characters5', {start: pc-1, end: pc+1}),
+				frameRate: 3,
+				repeat: -1,
+				yoyo: true
+			});
+
+			anims.create({
+				key: 'up' + pc,
+				frames: anims.generateFrameNumbers('characters5', {start: pc+35, end: pc+37}),
+				frameRate: 3,
+				repeat: -1,
+				yoyo: true
+			});
+
+			anims.create({
+				key: 'right' + pc,
+				frames: anims.generateFrameNumbers('characters5', {start: pc+23, end: pc+25}),
+				frameRate: 3,
+				repeat: -1,
+				yoyo: true
+			});
+			switch (pc) {
+				case 10:
+					pc = 49;
+					break;
+				default: 
+					pc+=3;
+			};
+		}
+		while (pc <= 58);
+	}
 }

--- a/Town.js
+++ b/Town.js
@@ -30,7 +30,7 @@ class Town extends Phaser.Scene{
 
 		level.setCollisionByProperty({ collides: true });
 
-		level.setCollisionByProperty({ door: true });
+//		level.setCollisionByProperty({ door: true });
 		this.moveGroup = this.physics.add.staticGroup();
 		var tileProps;
 		level.forEachTile(tile => {
@@ -69,12 +69,12 @@ class Town extends Phaser.Scene{
 		// create player
 		var icon = 1;
 		this.player = new Player(this, spawnPoint.x, spawnPoint.y, icon);
-		this.physics.add.collider(this.player, level);
+		this.physics.add.collider(this.player.sprite, level);
 
 		this.input.keyboard.on('keyup', function(e){
 			if (e.key=="j"){
-				const x = this.player.x;
-				const y = this.player.y;
+				const x = this.player.sprite.body.x;
+				const y = this.player.sprite.body.y;
 				switch (icon) {
 					case 10:
 						icon = 49;
@@ -87,7 +87,12 @@ class Town extends Phaser.Scene{
 				};
 				this.player.destroy();
 				this.player = new Player(this, x, y, icon);
+				this.physics.add.collider(this.player.sprite, level);
 			};
+			if (e.key=="l") {
+				console.log(this.player.sprite.body.x);
+				console.log(this.player.sprite.body.y);
+			};	
 		}, this);
 	}
 


### PR DESCRIPTION
Previous Issues: 
- Object collision not working properly
      + Collision working properly now using sprite body attributes
- Need to think of a way to implement idle animation depending on direction
      + Implemented idle animation using this.icon instance
- Changing character does not change movement animations
      + A bit of hardcoding, created all animations from the start using different character default sprites then cycle to the correct one
- When changing character, it is generated on initial spawnpoint instead of last character location
      + Used sprite body attributes to identify current x and y locations to update spawn location

Current issues:
- Changing character moves the character to the upper-left slightly
- Initial spawnpoint is a little too high, preventing the character from moving left or right (as they immediately hit collision wall)
      - Possible fix would be to have the character move down ("exit" the prior building) upon spawning
- Only one map for character to navigate